### PR TITLE
Raised dependency version cap on Unity.Abstractions.

### DIFF
--- a/src/Topshelf.Unity/Topshelf.Unity.nuspec
+++ b/src/Topshelf.Unity/Topshelf.Unity.nuspec
@@ -11,7 +11,7 @@
     <description>Topshelf.Unity provides extensions to construct your service class from your Unity IoC container.</description>
     <tags>Topshelf Unity</tags>
     <dependencies>
-      <dependency id="Unity.Abstractions" version="[2.0.0, 3.0.0)" />
+      <dependency id="Unity.Abstractions" version="[2.0.0, 3.*]" />
       <dependency id="Topshelf" version="[4.0.1,5.0.0)" />
     </dependencies>
   </metadata>


### PR DESCRIPTION
Fixes issue #6 by setting top limit to 3.* in nuspec.