### PR TITLE
Updated Unity and Unity.Abstractions version

### DIFF
--- a/src/Topshelf.Unity.Sample/Topshelf.Unity.Sample.csproj
+++ b/src/Topshelf.Unity.Sample/Topshelf.Unity.Sample.csproj
@@ -60,10 +60,10 @@
       <Version>3.1.1</Version>
     </PackageReference>
     <PackageReference Include="Unity">
-      <Version>5.5.5</Version>
+      <Version>5.8.0</Version>
     </PackageReference>
     <PackageReference Include="Unity.Abstractions">
-      <Version>3.1.2</Version>
+      <Version>3.3.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/Topshelf.Unity/Properties/AssemblyInfo.cs
+++ b/src/Topshelf.Unity/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Topshelf.Unity")]
-[assembly: AssemblyCopyright("Copyright ©  2014-2015")]
+[assembly: AssemblyCopyright("Copyright ©  2014-2018")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.1.0.0")]
-[assembly: AssemblyFileVersion("3.1.0.0")]
+[assembly: AssemblyVersion("3.1.1.0")]
+[assembly: AssemblyFileVersion("3.1.1.0")]

--- a/src/Topshelf.Unity/Topshelf.Unity.csproj
+++ b/src/Topshelf.Unity/Topshelf.Unity.csproj
@@ -45,8 +45,8 @@
     <Reference Include="Topshelf, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b800c4cfcdeea87b, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Topshelf.4.0.3\lib\net452\Topshelf.dll</HintPath>
     </Reference>
-    <Reference Include="Unity.Abstractions, Version=3.1.2.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Unity.Abstractions.3.1.2\lib\net45\Unity.Abstractions.dll</HintPath>
+    <Reference Include="Unity.Abstractions, Version=3.3.0.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Unity.Abstractions.3.3.0\lib\net45\Unity.Abstractions.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -57,7 +57,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="Topshelf.Unity.nuspec">
       <SubType>Designer</SubType>
     </None>

--- a/src/Topshelf.Unity/packages.config
+++ b/src/Topshelf.Unity/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Topshelf" version="4.0.3" targetFramework="net452" />
-  <package id="Unity.Abstractions" version="3.1.2" targetFramework="net452" />
+  <package id="Unity.Abstractions" version="3.3.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
This is just an update of Unity and Unity.Abstractions references, so there's no conflict when using it along with the latest version of Unity.