### PR TITLE
Update Unity references

### DIFF
--- a/src/Topshelf.Unity.Sample/Topshelf.Unity.Sample.csproj
+++ b/src/Topshelf.Unity.Sample/Topshelf.Unity.Sample.csproj
@@ -56,15 +56,18 @@
     <PackageReference Include="Topshelf">
       <Version>4.0.3</Version>
     </PackageReference>
-    <PackageReference Include="Topshelf.Unity">
-      <Version>3.1.1</Version>
-    </PackageReference>
     <PackageReference Include="Unity">
       <Version>5.8.0</Version>
     </PackageReference>
     <PackageReference Include="Unity.Abstractions">
       <Version>3.3.0</Version>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Topshelf.Unity\Topshelf.Unity.csproj">
+      <Project>{81469477-f982-41e0-829d-7fcf3f926068}</Project>
+      <Name>Topshelf.Unity</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/src/Topshelf.Unity.Sample/Topshelf.Unity.Sample.csproj
+++ b/src/Topshelf.Unity.Sample/Topshelf.Unity.Sample.csproj
@@ -57,10 +57,10 @@
       <Version>4.0.3</Version>
     </PackageReference>
     <PackageReference Include="Unity">
-      <Version>5.8.0</Version>
+      <Version>5.9.0</Version>
     </PackageReference>
     <PackageReference Include="Unity.Abstractions">
-      <Version>3.3.0</Version>
+      <Version>4.1.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Topshelf.Unity.Sample/app.config
+++ b/src/Topshelf.Unity.Sample/app.config
@@ -9,7 +9,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Unity.Abstractions" publicKeyToken="6d32ff45e0ccc69f" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.1.2.0" newVersion="3.1.2.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/Topshelf.Unity/Topshelf.Unity.csproj
+++ b/src/Topshelf.Unity/Topshelf.Unity.csproj
@@ -51,8 +51,8 @@
     <Reference Include="Topshelf, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b800c4cfcdeea87b, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Topshelf.4.0.3\lib\net452\Topshelf.dll</HintPath>
     </Reference>
-    <Reference Include="Unity.Abstractions, Version=3.3.0.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Unity.Abstractions.3.3.0\lib\net45\Unity.Abstractions.dll</HintPath>
+    <Reference Include="Unity.Abstractions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=489b6accfaf20ef0, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Unity.Abstractions.4.1.0\lib\net45\Unity.Abstractions.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Topshelf.Unity/packages.config
+++ b/src/Topshelf.Unity/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Topshelf" version="4.0.3" targetFramework="net452" />
-  <package id="Unity.Abstractions" version="3.3.0" targetFramework="net452" />
+  <package id="Unity.Abstractions" version="4.1.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
`Unity.Abstractions` v4+ is out. This PR updates the references to support that.
It also changes the Sample project to reference your `Topshelf.Unity` project via a project reference instead of NuGet.